### PR TITLE
No fork option

### DIFF
--- a/.github/workflows/SlackPrOpenNotify.yml
+++ b/.github/workflows/SlackPrOpenNotify.yml
@@ -19,6 +19,7 @@ jobs:
         PULL_REQUEST_BODY : ${{ github.event.pull_request.body }}
         PULL_REQUEST_COMPARE_BRANCH_OWNER: ${{ github.event.pull_request.head.repo.owner.login }}
         PULL_REQUEST_COMPARE_BRANCH_NAME : ${{ github.event.pull_request.head.ref }}
+        PULL_REQUEST_BASE_REPO_NAME: ${{ github.event.pull_request.base.repo.name }}
         PULL_REQUEST_BASE_BRANCH_OWNER: ${{ github.event.pull_request.base.repo.owner.login }}
         PULL_REQUEST_BASE_BRANCH_NAME : ${{ github.event.pull_request.base.ref }}
         IS_SEND_HERE_MENTION : true

--- a/.github/workflows/SlackPrOpenNotify.yml
+++ b/.github/workflows/SlackPrOpenNotify.yml
@@ -24,5 +24,4 @@ jobs:
         IS_SEND_HERE_MENTION : true
         MAKE_PRETTY : false
         MAKE_COMPACT : false
-        IS_PR_FROM_FORK: false
       uses: jun3453/slack-pr-open-notification-action@v1.1.0

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ jobs:
         PULL_REQUEST_COMPARE_BRANCH_NAME : ${{ github.event.pull_request.head.ref }}
         PULL_REQUEST_BASE_BRANCH_NAME : ${{ github.event.pull_request.base.ref }}
         IS_SEND_HERE_MENTION : true
+        MAKE_PRETTY : true
       uses: jun3453/slack-pr-open-notification-action@v1.0.3
 ```
 
@@ -41,3 +42,9 @@ See the following URL. https://developer.github.com/v3/pulls/
 
 #### IS_SEND_HERE_MENTION
 boolean. Whether to include a mention here when sending a message.
+
+#### MAKE_PRETTY
+boolean. Makes reading the info easier. Adds a "See Pull Request" button.
+
+#### MAKE_COMPACT
+boolean. Smaller visual footprint.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ jobs:
         IS_SEND_HERE_MENTION : true
         MAKE_PRETTY : false
         MAKE_COMPACT : false
-        IS_PR_FROM_FORK: false
+        ALWAYS_SHOW_OWNER: false
       uses: jun3453/slack-pr-open-notification-action@v1.2.0
 ```
 
@@ -60,9 +60,10 @@ Smaller visual footprint.
 
 ![make_compact](https://raw.githubusercontent.com/jun3453/slack-pr-open-notification-action/images/make_compact.png)
 
-#### IS_PR_FROM_FORK
+#### ALWAYS_SHOW_OWNER
 **boolean (DEFAULT: false)**  
-Whether notifications should support PRs from forks. By default, only the branch name is listed when sending a message.  
-If set to 'true', it will add the branch owner in front of the branch name ('owner:branch' vs 'branch'). If this option is used, you may need to enable fork pull request workflows under your repository's Actions settings.
+By default, if the PR comes from a fork, the owner and branch name are listed when sending a message. ('owner:branch' for external vs 'branch' for internal)
+If set to 'true', it will always show the owner in front of the branch name. 
+Please note that to accept external PRs, you may need to enable fork pull request workflows under your repository's Actions settings.
 
 ![make_compact and is_pr_fork](https://raw.githubusercontent.com/jun3453/slack-pr-open-notification-action/images/make_compact_fork.png)

--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ jobs:
         IS_SEND_HERE_MENTION : true
         MAKE_PRETTY : false
         MAKE_COMPACT : false
-        ALWAYS_SHOW_OWNER: false
       uses: jun3453/slack-pr-open-notification-action@v1.2.0
 ```
 
@@ -59,11 +58,3 @@ Pretty prints the information. Adds a "See Pull Request" button.
 Smaller visual footprint.
 
 ![make_compact](https://raw.githubusercontent.com/jun3453/slack-pr-open-notification-action/images/make_compact.png)
-
-#### ALWAYS_SHOW_OWNER
-**boolean (DEFAULT: false)**  
-By default, if the PR comes from a fork, the owner and branch name are listed when sending a message. ('owner:branch' for external vs 'branch' for internal)
-If set to 'true', it will always show the owner in front of the branch name. 
-Please note that to accept external PRs, you may need to enable fork pull request workflows under your repository's Actions settings.
-
-![make_compact and is_pr_fork](https://raw.githubusercontent.com/jun3453/slack-pr-open-notification-action/images/make_compact_fork.png)

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ jobs:
         PULL_REQUEST_BODY : ${{ github.event.pull_request.body }}
         PULL_REQUEST_COMPARE_BRANCH_OWNER: ${{ github.event.pull_request.head.repo.owner.login }}
         PULL_REQUEST_COMPARE_BRANCH_NAME : ${{ github.event.pull_request.head.ref }}
+        PULL_REQUEST_BASE_REPO_NAME: ${{ github.event.pull_request.base.repo.name }}
         PULL_REQUEST_BASE_BRANCH_OWNER: ${{ github.event.pull_request.base.repo.owner.login }}
         PULL_REQUEST_BASE_BRANCH_NAME : ${{ github.event.pull_request.base.ref }}
         IS_SEND_HERE_MENTION : true

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ jobs:
         PULL_REQUEST_BASE_BRANCH_NAME : ${{ github.event.pull_request.base.ref }}
         IS_SEND_HERE_MENTION : true
         MAKE_PRETTY : true
+        MAKE_COMPACT : false
       uses: jun3453/slack-pr-open-notification-action@v1.0.3
 ```
 
@@ -44,7 +45,7 @@ See the following URL. https://developer.github.com/v3/pulls/
 boolean. Whether to include a mention here when sending a message.
 
 #### MAKE_PRETTY
-boolean. Makes reading the info easier. Adds a "See Pull Request" button.
+boolean. Pretty prints the information. Adds a "See Pull Request" button.
 
 #### MAKE_COMPACT
 boolean. Smaller visual footprint.

--- a/SlackPrNotification.js
+++ b/SlackPrNotification.js
@@ -11,46 +11,142 @@ var authorIconUrl = process.env.PULL_REQUEST_AUTHOR_ICON_URL;
 var compareBranchName = process.env.PULL_REQUEST_COMPARE_BRANCH_NAME;
 var baseBranchName = process.env.PULL_REQUEST_BASE_BRANCH_NAME;
 var sendHereMention = process.env.IS_SEND_HERE_MENTION.toLowerCase() === "true" ? "<!here>\n" : "";
-var message = {
-    blocks: [
-        {
-            type: "section",
-            text: {
-                type: "mrkdwn",
-                text: sendHereMention + "*<" + prUrl + "|" + prTitle + ">*"
-            },
-            accessory: {
-                type: "image",
-                image_url: authorIconUrl,
-                alt_text: "github icon"
-            },
-            fields: [
+var makePretty  = process.env.MAKE_PRETTY.toLowerCase() === "true"; //Priority is pretty > compact > normal
+var makeCompact = process.env.MAKE_COMPACT.toLowerCase() === "true";
+
+if (makePretty){
+    var message = {
+        attachments: [
+            {
+                color: "#00ff00",
+                blocks: [
                 {
-                    type: "mrkdwn",
-                    text: "*Author*\n" + authorName
+                    type: "section",
+                    block_id: "commit_title",
+                    text: {
+                        type: "mrkdwn",
+                        text: prNum + "*" + prTitle + "* requests merge from *" + baseBranchName + "* to *" + compareBranchName + "." + sendHereMention
+                    }
                 },
                 {
-                    type: "mrkdwn",
-                    text: "*Base branch*\n" + baseBranchName
+                    type: "context",
+                    block_id: "committer_meta",
+                    elements: [
+                        {
+                            type: "image",
+                            image_url: authorIconUrl,
+                            alt_text: "images"
+                        },
+                        {
+                            type: "mrkdwn",
+                            text: authorName
+                        }
+                    ]
                 },
                 {
-                    type: "mrkdwn",
-                    text: "*Pull request number*\n#" + prNum
-                },
-                {
-                    type: "mrkdwn",
-                    text: "*Compare branch*\n" + compareBranchName
-                },
-            ]
-        },
-        {
-            type: "section",
-            text: {
-                type: "plain_text",
-                text: prBody,
-                emoji: true
+                    type: "actions",
+                    elements: [
+                    {
+                        type: "button",
+                        text: {
+                            type: "plain_text",
+                            text: "See Pull Request",
+                            emoji: true
+                        },
+                        value: prTitle,
+                        url: prUrl,
+                        action_id: "actionId-0",
+                        style: "primary"
+                    },
+                    {
+                        type: "button",
+                        text: {
+                            type: "plain_text",
+                            text: "Contact Sender",
+                            emoji: true
+                        },
+                        value: "Author's email",
+                        url: "mailto:" + authorEmail,
+                        action_id: "actionId-1"
+                    }
+                    ]
+                }
+                ]
             }
-        },
-    ]
-};
+        ]
+    }
+}
+else if (makeCompact) {
+    var message = {
+        blocks: [
+            {
+                type: "section",
+                block_id: "commit_title",
+                text: {
+                    type: "mrkdwn",
+                    text: "*<" + prUrl + "|" + prTitle + ">* " + prNum + " for *" + baseBranchName + "* to *" + compareBranchName + "." + sendHereMention
+                }
+            },
+            {
+                type: "context",
+                block_id: "committer_meta",
+                elements: [
+                    {
+                        type: "image",
+                        image_url: authorIconUrl,
+                        alt_text: "images"
+                    },
+                    {
+                        type: "mrkdwn",
+                        text: "*<" + authorName + "|mailto:" + authorEmail + ">*"
+                    }
+                ]
+            }
+        ]
+    }
+}
+else{
+    var message = {
+        blocks: [
+            {
+                type: "section",
+                text: {
+                    type: "mrkdwn",
+                    text: sendHereMention + "*<" + prUrl + "|" + prTitle + ">*"
+                },
+                accessory: {
+                    type: "image",
+                    image_url: authorIconUrl,
+                    alt_text: "github icon"
+                },
+                fields: [
+                    {
+                        type: "mrkdwn",
+                        text: "*Author*\n" + authorName
+                    },
+                    {
+                        type: "mrkdwn",
+                        text: "*Base branch*\n" + baseBranchName
+                    },
+                    {
+                        type: "mrkdwn",
+                        text: "*Pull request number*\n#" + prNum
+                    },
+                    {
+                        type: "mrkdwn",
+                        text: "*Compare branch*\n" + compareBranchName
+                    },
+                ]
+            },
+            {
+                type: "section",
+                text: {
+                    type: "plain_text",
+                    text: prBody,
+                    emoji: true
+                }
+            },
+        ]
+    };
+}
 axios_1["default"].post(url, message);

--- a/SlackPrNotification.js
+++ b/SlackPrNotification.js
@@ -73,7 +73,7 @@ else if (makeCompact) {
                 block_id: "commit_title",
                 text: {
                     type: "mrkdwn",
-                    text: "*<" + prUrl + "|" + prTitle + ">* #" + prNum + " for *" + baseBranchName + "* to *" + compareBranchName + "*." + sendHereMention
+                    text: "*<" + prUrl + "|" + prTitle + ">* #" + prNum + " from *" + baseBranchName + "* to *" + compareBranchName + "*." + sendHereMention
                 }
             },
             {

--- a/SlackPrNotification.js
+++ b/SlackPrNotification.js
@@ -7,6 +7,7 @@ var prTitle = process.env.PULL_REQUEST_TITLE;
 var prUrl = process.env.PULL_REQUEST_URL;
 var prBody = process.env.PULL_REQUEST_BODY || "No description provided.";
 var authorName = process.env.PULL_REQUEST_AUTHOR_NAME;
+var authorEmail = process.env.PULL_REQUEST_AUTHOR_EMAIL;
 var authorIconUrl = process.env.PULL_REQUEST_AUTHOR_ICON_URL;
 var compareBranchName = process.env.PULL_REQUEST_COMPARE_BRANCH_NAME;
 var baseBranchName = process.env.PULL_REQUEST_BASE_BRANCH_NAME;

--- a/SlackPrNotification.js
+++ b/SlackPrNotification.js
@@ -63,7 +63,7 @@ if (makePretty){
                         type: "button",
                         text: {
                             type: "plain_text",
-                            text: "Contact Sender",
+                            text: "Contact" + authorEmail,
                             emoji: true
                         },
                         value: "Author's email",

--- a/SlackPrNotification.js
+++ b/SlackPrNotification.js
@@ -13,11 +13,19 @@ var compareBranchName = process.env.PULL_REQUEST_COMPARE_BRANCH_NAME;
 var baseBranchOwner = process.env.PULL_REQUEST_BASE_BRANCH_OWNER;
 var baseBranchName = process.env.PULL_REQUEST_BASE_BRANCH_NAME;
 var sendHereMention = process.env.IS_SEND_HERE_MENTION.toLowerCase() === "true" ? "<!here>\n" : "";
-var prFromFork = process.env.IS_PR_FROM_FORK;
-var compareBranchText = prFromFork === "true" ? compareBranchOwner + ":" + compareBranchName : compareBranchName;
-var baseBranchText = prFromFork === "true" ? baseBranchOwner + ":" + baseBranchName : baseBranchName;
 var makePretty = process.env.MAKE_PRETTY.toLowerCase() === "true"; //Priority is pretty > compact > normal
 var makeCompact = process.env.MAKE_COMPACT.toLowerCase() === "true";
+var alwaysShowOWner = process.env.ALWAYS_SHOW_OWNER;
+
+if (!alwaysShowOWner){
+    var compareBranchText = compareBranchName !== baseBranchName ? compareBranchOwner + ":" + compareBranchName : compareBranchName;
+    var baseBranchText = baseBranchName !== compareBranchName ? baseBranchOwner + ":" + baseBranchName : baseBranchName;
+}else {
+    var compareBranchText = compareBranchOwner + ":" + compareBranchName;
+    var baseBranchText = baseBranchOwner + ":" + baseBranchName;
+}
+
+
 if (makePretty) {
     var message = {
         attachments: [
@@ -29,7 +37,7 @@ if (makePretty) {
                         block_id: "commit_title",
                         text: {
                             type: "mrkdwn",
-                            text: "[*#" + prNum + "*] *" + prTitle + "* requests merge from *" + baseBranchName + "* to *" + compareBranchName + "*." + sendHereMention
+                            text: "[*#" + prNum + "*] *" + prTitle + "* from *" + baseBranchText + "* to *" + compareBranchText + "*." + sendHereMention
                         }
                     },
                     {
@@ -46,6 +54,14 @@ if (makePretty) {
                                 text: authorName
                             }
                         ]
+                    },                    
+                    {
+                        type: "section",
+                        block_id: "pr_description",
+                        text: {
+                            type: "mrkdwn",
+                            text: prBody
+                        }
                     },
                     {
                         type: "actions",

--- a/SlackPrNotification.js
+++ b/SlackPrNotification.js
@@ -15,15 +15,9 @@ var baseBranchName = process.env.PULL_REQUEST_BASE_BRANCH_NAME;
 var sendHereMention = process.env.IS_SEND_HERE_MENTION.toLowerCase() === "true" ? "<!here>\n" : "";
 var makePretty = process.env.MAKE_PRETTY.toLowerCase() === "true"; //Priority is pretty > compact > normal
 var makeCompact = process.env.MAKE_COMPACT.toLowerCase() === "true";
-var alwaysShowOWner = process.env.ALWAYS_SHOW_OWNER;
 
-if (!alwaysShowOWner){
-    var compareBranchText = compareBranchOwner !== baseBranchOwner ? compareBranchOwner + ":" + compareBranchName : compareBranchName;
-    var baseBranchText = baseBranchOwner !== compareBranchOwner ? baseBranchOwner + ":" + baseBranchName : baseBranchName;
-}else {
-    var compareBranchText = compareBranchOwner + ":" + compareBranchName;
-    var baseBranchText = baseBranchOwner + ":" + baseBranchName;
-}
+var baseBranchText = baseBranchOwner + ":" + baseBranchName;
+var compareBranchText = compareBranchOwner !== baseBranchOwner ? compareBranchOwner + ":" + compareBranchName : compareBranchName;
 
 
 if (makePretty) {

--- a/SlackPrNotification.js
+++ b/SlackPrNotification.js
@@ -25,7 +25,7 @@ if (makePretty){
                     block_id: "commit_title",
                     text: {
                         type: "mrkdwn",
-                        text: "(#" + prNum + ") *" + prTitle + "* requests merge from *" + baseBranchName + "* to *" + compareBranchName + "*." + sendHereMention
+                        text: "[*#" + prNum + "*] *" + prTitle + "* requests merge from *" + baseBranchName + "* to *" + compareBranchName + "*." + sendHereMention
                     }
                 },
                 {

--- a/SlackPrNotification.js
+++ b/SlackPrNotification.js
@@ -7,7 +7,6 @@ var prTitle = process.env.PULL_REQUEST_TITLE;
 var prUrl = process.env.PULL_REQUEST_URL;
 var prBody = process.env.PULL_REQUEST_BODY || "No description provided.";
 var authorName = process.env.PULL_REQUEST_AUTHOR_NAME;
-var authorEmail = process.env.PULL_REQUEST_COMMITTER_EMAIL;
 var authorIconUrl = process.env.PULL_REQUEST_AUTHOR_ICON_URL;
 var compareBranchName = process.env.PULL_REQUEST_COMPARE_BRANCH_NAME;
 var baseBranchName = process.env.PULL_REQUEST_BASE_BRANCH_NAME;
@@ -26,7 +25,7 @@ if (makePretty){
                     block_id: "commit_title",
                     text: {
                         type: "mrkdwn",
-                        text: "PR#" + prNum + " *" + prTitle + "* requests merge from *" + baseBranchName + "* to *" + compareBranchName + "*." + sendHereMention
+                        text: "(#" + prNum + ") *" + prTitle + "* requests merge from *" + baseBranchName + "* to *" + compareBranchName + "*." + sendHereMention
                     }
                 },
                 {
@@ -58,17 +57,6 @@ if (makePretty){
                         url: prUrl,
                         action_id: "actionId-0",
                         style: "primary"
-                    },
-                    {
-                        type: "button",
-                        text: {
-                            type: "plain_text",
-                            text: "Contact" + authorEmail,
-                            emoji: true
-                        },
-                        value: "Author's email",
-                        url: "mailto:" + authorEmail,
-                        action_id: "actionId-1"
                     }
                     ]
                 }
@@ -99,7 +87,7 @@ else if (makeCompact) {
                     },
                     {
                         type: "mrkdwn",
-                        text: "*<" + authorName + "|mailto:" + authorEmail + ">*"
+                        text: "*" + authorName + "*"
                     }
                 ]
             }

--- a/SlackPrNotification.js
+++ b/SlackPrNotification.js
@@ -30,7 +30,7 @@ if (makePretty) {
                         block_id: "commit_title",
                         text: {
                             type: "mrkdwn",
-                            text: "[*#" + prNum + "*] *" + prTitle + "* from *" + baseBranchText + "* to *" + compareBranchText + "*." + sendHereMention
+                            text: "[*#" + prNum + "*] *" + prTitle + "* from *" + compareBranchText + "* to *" + baseBranchText + "*." + sendHereMention
                         }
                     },
                     {
@@ -87,7 +87,7 @@ else if (makeCompact) {
                 block_id: "commit_title",
                 text: {
                     type: "mrkdwn",
-                    text: "*<" + prUrl + "|" + prTitle + ">* #" + prNum + " from *" + baseBranchText + "* to *" + compareBranchText + "*." + sendHereMention
+                    text: "*<" + prUrl + "|" + prTitle + ">* #" + prNum + " from *" + compareBranchText  + "* to *" + baseBranchText + "*." + sendHereMention
                 }
             },
             {

--- a/SlackPrNotification.js
+++ b/SlackPrNotification.js
@@ -18,8 +18,8 @@ var makeCompact = process.env.MAKE_COMPACT.toLowerCase() === "true";
 var alwaysShowOWner = process.env.ALWAYS_SHOW_OWNER;
 
 if (!alwaysShowOWner){
-    var compareBranchText = compareBranchName !== baseBranchName ? compareBranchOwner + ":" + compareBranchName : compareBranchName;
-    var baseBranchText = baseBranchName !== compareBranchName ? baseBranchOwner + ":" + baseBranchName : baseBranchName;
+    var compareBranchText = compareBranchOwner !== baseBranchOwner ? compareBranchOwner + ":" + compareBranchName : compareBranchName;
+    var baseBranchText = baseBranchOwner !== compareBranchOwner ? baseBranchOwner + ":" + baseBranchName : baseBranchName;
 }else {
     var compareBranchText = compareBranchOwner + ":" + compareBranchName;
     var baseBranchText = baseBranchOwner + ":" + baseBranchName;

--- a/SlackPrNotification.js
+++ b/SlackPrNotification.js
@@ -19,7 +19,6 @@ var makeCompact = process.env.MAKE_COMPACT.toLowerCase() === "true";
 var baseBranchText = baseBranchOwner + ":" + baseBranchName;
 var compareBranchText = compareBranchOwner !== baseBranchOwner ? compareBranchOwner + ":" + compareBranchName : compareBranchName;
 
-
 if (makePretty) {
     var message = {
         attachments: [

--- a/SlackPrNotification.js
+++ b/SlackPrNotification.js
@@ -26,7 +26,7 @@ if (makePretty){
                     block_id: "commit_title",
                     text: {
                         type: "mrkdwn",
-                        text: prNum + "*" + prTitle + "* requests merge from *" + baseBranchName + "* to *" + compareBranchName + "." + sendHereMention
+                        text: "PR#" + prNum + " *" + prTitle + "* requests merge from *" + baseBranchName + "* to *" + compareBranchName + "*." + sendHereMention
                     }
                 },
                 {
@@ -85,7 +85,7 @@ else if (makeCompact) {
                 block_id: "commit_title",
                 text: {
                     type: "mrkdwn",
-                    text: "*<" + prUrl + "|" + prTitle + ">* " + prNum + " for *" + baseBranchName + "* to *" + compareBranchName + "." + sendHereMention
+                    text: " *<" + prUrl + "|" + prTitle + ">* #" + prNum + " for *" + baseBranchName + "* to *" + compareBranchName + "*." + sendHereMention
                 }
             },
             {

--- a/SlackPrNotification.js
+++ b/SlackPrNotification.js
@@ -10,13 +10,14 @@ var authorName = process.env.PULL_REQUEST_AUTHOR_NAME;
 var authorIconUrl = process.env.PULL_REQUEST_AUTHOR_ICON_URL;
 var compareBranchOwner = process.env.PULL_REQUEST_COMPARE_BRANCH_OWNER;
 var compareBranchName = process.env.PULL_REQUEST_COMPARE_BRANCH_NAME;
+var baseRepoName = process.env.PULL_REQUEST_BASE_REPO_NAME;
 var baseBranchOwner = process.env.PULL_REQUEST_BASE_BRANCH_OWNER;
 var baseBranchName = process.env.PULL_REQUEST_BASE_BRANCH_NAME;
 var sendHereMention = process.env.IS_SEND_HERE_MENTION.toLowerCase() === "true" ? "<!here>\n" : "";
 var makePretty = process.env.MAKE_PRETTY.toLowerCase() === "true"; //Priority is pretty > compact > normal
 var makeCompact = process.env.MAKE_COMPACT.toLowerCase() === "true";
 
-var baseBranchText = baseBranchOwner + ":" + baseBranchName;
+var baseBranchText = baseRepoName + ":" + baseBranchName;
 var compareBranchText = compareBranchOwner !== baseBranchOwner ? compareBranchOwner + ":" + compareBranchName : compareBranchName;
 
 if (makePretty) {

--- a/SlackPrNotification.js
+++ b/SlackPrNotification.js
@@ -7,7 +7,7 @@ var prTitle = process.env.PULL_REQUEST_TITLE;
 var prUrl = process.env.PULL_REQUEST_URL;
 var prBody = process.env.PULL_REQUEST_BODY || "No description provided.";
 var authorName = process.env.PULL_REQUEST_AUTHOR_NAME;
-var authorEmail = process.env.PULL_REQUEST_AUTHOR_EMAIL;
+var authorEmail = process.env.PULL_REQUEST_COMMITTER_EMAIL;
 var authorIconUrl = process.env.PULL_REQUEST_AUTHOR_ICON_URL;
 var compareBranchName = process.env.PULL_REQUEST_COMPARE_BRANCH_NAME;
 var baseBranchName = process.env.PULL_REQUEST_BASE_BRANCH_NAME;
@@ -85,7 +85,7 @@ else if (makeCompact) {
                 block_id: "commit_title",
                 text: {
                     type: "mrkdwn",
-                    text: " *<" + prUrl + "|" + prTitle + ">* #" + prNum + " for *" + baseBranchName + "* to *" + compareBranchName + "*." + sendHereMention
+                    text: "*<" + prUrl + "|" + prTitle + ">* #" + prNum + " for *" + baseBranchName + "* to *" + compareBranchName + "*." + sendHereMention
                 }
             },
             {

--- a/SlackPrNotification.ts
+++ b/SlackPrNotification.ts
@@ -64,7 +64,7 @@ if (makePretty) {
                         type: "button",
                         text: {
                             type: "plain_text",
-                            text: "Contact Sender",
+                            text: "Contact " + authorEmail,
                             emoji: true
                         },
                         value: "Author's email",

--- a/SlackPrNotification.ts
+++ b/SlackPrNotification.ts
@@ -30,7 +30,7 @@ if (makePretty) {
                         block_id: "commit_title",
                         text: {
                             type: "mrkdwn",
-                            text: "*<" + prUrl + "|" + prTitle + ">* #" + prNum + " from *" + baseBranchText + "* to *" + compareBranchText + "*." + sendHereMention
+                            text: "*<" + prUrl + "|" + prTitle + ">* #" + prNum + " from *" + compareBranchText + "* to *" +  baseBranchText + "*." + sendHereMention
                         }
                     },
                     {

--- a/SlackPrNotification.ts
+++ b/SlackPrNotification.ts
@@ -15,18 +15,9 @@ const sendHereMention: string = process.env.IS_SEND_HERE_MENTION.toLowerCase() =
 
 const makePretty: boolean = process.env.MAKE_PRETTY.toLowerCase() === "true"; //Priority is pretty > compact > normal
 const makeCompact: boolean = process.env.MAKE_COMPACT.toLowerCase() === "true";
-const alwaysShowOWner: boolean = process.env.ALWAYS_SHOW_OWNER.toLowerCase() === "true";
 
-var compareBranchText: string;
-var baseBranchText: string;
-
-if (!alwaysShowOWner){
-    compareBranchText = compareBranchOwner !== baseBranchOwner ? compareBranchOwner + ":" + compareBranchName : compareBranchName;
-    baseBranchText = baseBranchOwner !== compareBranchOwner ? baseBranchOwner + ":" + baseBranchName : baseBranchName;
-}else {
-    compareBranchText = compareBranchOwner + ":" + compareBranchName;
-    baseBranchText = baseBranchOwner + ":" + baseBranchName;
-}
+const baseBranchText: string = baseBranchOwner + ":" + baseBranchName;
+const compareBranchText: string = compareBranchOwner !== baseBranchOwner ? compareBranchOwner + ":" + compareBranchName : compareBranchName;
 
 if (makePretty) {
     const message: Object = {

--- a/SlackPrNotification.ts
+++ b/SlackPrNotification.ts
@@ -9,6 +9,7 @@ const authorName: string = process.env.PULL_REQUEST_AUTHOR_NAME;
 const authorIconUrl: string = process.env.PULL_REQUEST_AUTHOR_ICON_URL;
 const compareBranchOwner: string = process.env.PULL_REQUEST_COMPARE_BRANCH_OWNER;
 const compareBranchName: string = process.env.PULL_REQUEST_COMPARE_BRANCH_NAME;
+const baseRepoName: string = process.env.PULL_REQUEST_BASE_REPO_NAME;
 const baseBranchOwner: string = process.env.PULL_REQUEST_BASE_BRANCH_OWNER;
 const baseBranchName: string = process.env.PULL_REQUEST_BASE_BRANCH_NAME;
 const sendHereMention: string = process.env.IS_SEND_HERE_MENTION.toLowerCase() === "true" ? "<!here>\n" : "";
@@ -16,7 +17,7 @@ const sendHereMention: string = process.env.IS_SEND_HERE_MENTION.toLowerCase() =
 const makePretty: boolean = process.env.MAKE_PRETTY.toLowerCase() === "true"; //Priority is pretty > compact > normal
 const makeCompact: boolean = process.env.MAKE_COMPACT.toLowerCase() === "true";
 
-const baseBranchText: string = baseBranchOwner + ":" + baseBranchName;
+const baseBranchText: string = baseRepoName + ":" + baseBranchName;
 const compareBranchText: string = compareBranchOwner !== baseBranchOwner ? compareBranchOwner + ":" + compareBranchName : compareBranchName;
 
 if (makePretty) {
@@ -78,7 +79,7 @@ if (makePretty) {
                 block_id: "commit_title",
                 text: {
                     type: "mrkdwn",
-                    text: "*<" + prUrl + "|" + prTitle + ">* #" + prNum + " from *" + baseBranchText + "* to *" + compareBranchText + "*." + sendHereMention
+                    text: "*<" + prUrl + "|" + prTitle + ">* #" + prNum + " from *" + compareBranchText + "* to *" + baseBranchText + "*." + sendHereMention
                 }
             },
             {

--- a/SlackPrNotification.ts
+++ b/SlackPrNotification.ts
@@ -26,7 +26,7 @@ if (makePretty) {
                     block_id: "commit_title",
                     text: {
                         type: "mrkdwn",
-                        text: "*<" + prUrl + "|" + prTitle + ">* #" + prNum + " for *" + baseBranchName + "* to *" + compareBranchName + "*." + sendHereMention
+                        text: "*<" + prUrl + "|" + prTitle + ">* #" + prNum + " from *" + baseBranchName + "* to *" + compareBranchName + "*." + sendHereMention
                     }
                 },
                 {
@@ -73,7 +73,7 @@ if (makePretty) {
             block_id: "commit_title",
             text: {
                 type: "mrkdwn",
-                text: "*<" + prUrl + "|" + prTitle + ">* #" + prNum + " for *" + baseBranchName + "* to *" + compareBranchName + "*." + sendHereMention
+                text: "*<" + prUrl + "|" + prTitle + ">* #" + prNum + " from *" + baseBranchName + "* to *" + compareBranchName + "*." + sendHereMention
             }
         },
         {

--- a/SlackPrNotification.ts
+++ b/SlackPrNotification.ts
@@ -7,7 +7,6 @@ const prTitle: string = process.env.PULL_REQUEST_TITLE;
 const prUrl: string = process.env.PULL_REQUEST_URL;
 const prBody: string = process.env.PULL_REQUEST_BODY || "No description provided.";
 const authorName: string = process.env.PULL_REQUEST_AUTHOR_NAME;
-const authorEmail: string = process.env.PULL_REQUEST_AUTHOR_EMAIL;
 const authorIconUrl: string = process.env.PULL_REQUEST_AUTHOR_ICON_URL;
 const compareBranchName: string = process.env.PULL_REQUEST_COMPARE_BRANCH_NAME;
 const baseBranchName: string = process.env.PULL_REQUEST_BASE_BRANCH_NAME;
@@ -27,7 +26,7 @@ if (makePretty) {
                     block_id: "commit_title",
                     text: {
                         type: "mrkdwn",
-                        text: prNum + "*" + prTitle + "* requests merge from *" + baseBranchName + "* to *" + compareBranchName + "." + sendHereMention
+                        text: "*<" + prUrl + "|" + prTitle + ">* #" + prNum + " for *" + baseBranchName + "* to *" + compareBranchName + "*." + sendHereMention
                     }
                 },
                 {
@@ -59,17 +58,6 @@ if (makePretty) {
                         url: prUrl,
                         action_id: "actionId-0",
                         style: "primary"
-                    },
-                    {
-                        type: "button",
-                        text: {
-                            type: "plain_text",
-                            text: "Contact " + authorEmail,
-                            emoji: true
-                        },
-                        value: "Author's email",
-                        url: "mailto:" + authorEmail,
-                        action_id: "actionId-1"
                     }
                     ]
                 }
@@ -99,7 +87,7 @@ if (makePretty) {
                 },
                 {
                     type: "mrkdwn",
-                    text: "*<" + authorName + "|mailto:" + authorEmail + ">*"
+                    text: "*" + authorName + "*"
                 }
             ]
         }

--- a/SlackPrNotification.ts
+++ b/SlackPrNotification.ts
@@ -85,7 +85,7 @@ if (makePretty) {
             block_id: "commit_title",
             text: {
                 type: "mrkdwn",
-                text: "*<" + prUrl + "|" + prTitle + ">* " + prNum + " for *" + baseBranchName + "* to *" + compareBranchName + "." + sendHereMention
+                text: "*<" + prUrl + "|" + prTitle + ">* #" + prNum + " for *" + baseBranchName + "* to *" + compareBranchName + "*." + sendHereMention
             }
         },
         {

--- a/SlackPrNotification.ts
+++ b/SlackPrNotification.ts
@@ -13,12 +13,20 @@ const baseBranchOwner: string = process.env.PULL_REQUEST_BASE_BRANCH_OWNER;
 const baseBranchName: string = process.env.PULL_REQUEST_BASE_BRANCH_NAME;
 const sendHereMention: string = process.env.IS_SEND_HERE_MENTION.toLowerCase() === "true" ? "<!here>\n" : "";
 
-const prFromFork: string = process.env.IS_PR_FROM_FORK;
-const compareBranchText: string = prFromFork === "true" ? compareBranchOwner + ":" + compareBranchName : compareBranchName;
-const baseBranchText: string = prFromFork === "true" ? baseBranchOwner + ":" + baseBranchName : baseBranchName;
-
 const makePretty: boolean = process.env.MAKE_PRETTY.toLowerCase() === "true"; //Priority is pretty > compact > normal
 const makeCompact: boolean = process.env.MAKE_COMPACT.toLowerCase() === "true";
+const alwaysShowOWner: boolean = process.env.ALWAYS_SHOW_OWNER.toLowerCase() === "true";
+
+var compareBranchText: string;
+var baseBranchText: string;
+
+if (!alwaysShowOWner){
+    compareBranchText = compareBranchName !== baseBranchName ? compareBranchOwner + ":" + compareBranchName : compareBranchName;
+    baseBranchText = baseBranchName !== compareBranchName ? baseBranchOwner + ":" + baseBranchName : baseBranchName;
+}else {
+    compareBranchText = compareBranchOwner + ":" + compareBranchName;
+    baseBranchText = baseBranchOwner + ":" + baseBranchName;
+}
 
 if (makePretty) {
     const message: Object = {

--- a/SlackPrNotification.ts
+++ b/SlackPrNotification.ts
@@ -7,53 +7,147 @@ const prTitle: string = process.env.PULL_REQUEST_TITLE;
 const prUrl: string = process.env.PULL_REQUEST_URL;
 const prBody: string = process.env.PULL_REQUEST_BODY || "No description provided.";
 const authorName: string = process.env.PULL_REQUEST_AUTHOR_NAME;
+const authorEmail: string = process.env.PULL_REQUEST_AUTHOR_EMAIL;
 const authorIconUrl: string = process.env.PULL_REQUEST_AUTHOR_ICON_URL;
 const compareBranchName: string = process.env.PULL_REQUEST_COMPARE_BRANCH_NAME;
 const baseBranchName: string = process.env.PULL_REQUEST_BASE_BRANCH_NAME;
 
 const sendHereMention: string = process.env.IS_SEND_HERE_MENTION.toLowerCase() === "true" ? "<!here>\n" : "";
+const makePretty: boolean = process.env.MAKE_PRETTY.toLowerCase() === "true"; //Priority is pretty > compact > normal
+const makeCompact: boolean = process.env.MAKE_COMPACT.toLowerCase() === "true";
 
-const message: Object = {
+if (makePretty) {
+    const message: Object = {
+        attachments: [
+            {
+                color: "#00ff00",
+                blocks: [
+                {
+                    type: "section",
+                    block_id: "commit_title",
+                    text: {
+                        type: "mrkdwn",
+                        text: prNum + "*" + prTitle + "* requests merge from *" + baseBranchName + "* to *" + compareBranchName + "." + sendHereMention
+                    }
+                },
+                {
+                    type: "context",
+                    block_id: "committer_meta",
+                    elements: [
+                        {
+                            type: "image",
+                            image_url: authorIconUrl,
+                            alt_text: "images"
+                        },
+                        {
+                            type: "mrkdwn",
+                            text: authorName
+                        }
+                    ]
+                },
+                {
+                    type: "actions",
+                    elements: [
+                    {
+                        type: "button",
+                        text: {
+                            type: "plain_text",
+                            text: "See Pull Request",
+                            emoji: true
+                        },
+                        value: prTitle,
+                        url: prUrl,
+                        action_id: "actionId-0",
+                        style: "primary"
+                    },
+                    {
+                        type: "button",
+                        text: {
+                            type: "plain_text",
+                            text: "Contact Sender",
+                            emoji: true
+                        },
+                        value: "Author's email",
+                        url: "mailto:" + authorEmail,
+                        action_id: "actionId-1"
+                    }
+                    ]
+                }
+                ]
+            }
+        ]
+    }
+    axios.post(url, message);
+}else if (makeCompact){ const message: Object = {
     blocks: [
         {
             type: "section",
+            block_id: "commit_title",
             text: {
                 type: "mrkdwn",
-                text: sendHereMention + "*<" + prUrl + "|" + prTitle + ">*",
-            },
-            accessory: {
-                type: "image",
-                image_url: authorIconUrl,
-                alt_text: "github icon",
-            },
-            fields: [
-                {
-                    type: "mrkdwn",
-                    text: "*Author*\n" + authorName,
-                },
-                {
-                    type: "mrkdwn",
-                    text: "*Base branch*\n" + baseBranchName,
-                },
-                {
-                    type: "mrkdwn",
-                    text: "*Pull request number*\n#" + prNum,
-                },
-                {
-                    type: "mrkdwn",
-                    text: "*Compare branch*\n" + compareBranchName,
-                },
-            ],
+                text: "*<" + prUrl + "|" + prTitle + ">* " + prNum + " for *" + baseBranchName + "* to *" + compareBranchName + "." + sendHereMention
+            }
         },
         {
-            type: "section",
-            text: {
-                type: "plain_text",
-                text: prBody,
-                emoji: true,
-            },
-        },
+            type: "context",
+            block_id: "committer_meta",
+            elements: [
+                {
+                    type: "image",
+                    image_url: authorIconUrl,
+                    alt_text: "images"
+                },
+                {
+                    type: "mrkdwn",
+                    text: "*<" + authorName + "|mailto:" + authorEmail + ">*"
+                }
+            ]
+        }
     ]
-};
-
-axios.post(url, message);
+    }
+    axios.post(url, message);
+}else {
+    const message: Object = {
+        blocks: [
+            {
+                type: "section",
+                text: {
+                    type: "mrkdwn",
+                    text: sendHereMention + "*<" + prUrl + "|" + prTitle + ">*",
+                },
+                accessory: {
+                    type: "image",
+                    image_url: authorIconUrl,
+                    alt_text: "github icon",
+                },
+                fields: [
+                    {
+                        type: "mrkdwn",
+                        text: "*Author*\n" + authorName,
+                    },
+                    {
+                        type: "mrkdwn",
+                        text: "*Base branch*\n" + baseBranchName,
+                    },
+                    {
+                        type: "mrkdwn",
+                        text: "*Pull request number*\n#" + prNum,
+                    },
+                    {
+                        type: "mrkdwn",
+                        text: "*Compare branch*\n" + compareBranchName,
+                    },
+                ],
+            },
+            {
+                type: "section",
+                text: {
+                    type: "plain_text",
+                    text: prBody,
+                    emoji: true,
+                },
+            },
+        ]
+    };
+    axios.post(url, message);
+}

--- a/SlackPrNotification.ts
+++ b/SlackPrNotification.ts
@@ -21,8 +21,8 @@ var compareBranchText: string;
 var baseBranchText: string;
 
 if (!alwaysShowOWner){
-    compareBranchText = compareBranchName !== baseBranchName ? compareBranchOwner + ":" + compareBranchName : compareBranchName;
-    baseBranchText = baseBranchName !== compareBranchName ? baseBranchOwner + ":" + baseBranchName : baseBranchName;
+    compareBranchText = compareBranchOwner !== baseBranchOwner ? compareBranchOwner + ":" + compareBranchName : compareBranchName;
+    baseBranchText = baseBranchOwner !== compareBranchOwner ? baseBranchOwner + ":" + baseBranchName : baseBranchName;
 }else {
     compareBranchText = compareBranchOwner + ":" + compareBranchName;
     baseBranchText = baseBranchOwner + ":" + baseBranchName;


### PR DESCRIPTION
Warning: breaking change.

I believe the option added by @mgilardi IS_PR_FROM_FORK can be automated.

With this commit, I always print baseRepoName:branchName.
I check if baseBranchOwner !== compareBranchOwner and if so, I print compareBranchOwner:compareBranchName.
If not, I print compareBranchName only.
![same repo pretty](https://user-images.githubusercontent.com/10896151/125776642-9b2fa9ad-4112-46b4-ac05-c6b024ebe95a.png)

I do not believe that always printing the base owner is a lot of visual clutter. It also indicates what repository we are on.
I also believe that only writing the owner if he is an external (fork) is a good visual cue.

![very serious description](https://user-images.githubusercontent.com/10896151/125776937-28706ec1-16cd-4347-b668-edeea0ad44c6.png)
